### PR TITLE
Use `he` for improved HTML entity decoding

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -2,7 +2,7 @@
 var url     = require('url')
   , request = require('request')
   , $       = require('jquery')
-  , ent     = require('ent')
+  , decode  = require('he').decode
   , clone   = require('./clone')
   ;
 
@@ -88,7 +88,7 @@ var parseTorrents = function(body, callback) {
       t.artist = parseArtist(td3a.first());
 
       // relesae info
-      parsedHref = url.parse(ent.decode(td3a.eq(1).attr('href')), true);
+      parsedHref = url.parse(decode(td3a.eq(1).attr('href')), true);
       n = t.artist === null ? 0 : 1;
       t.release = parseRelease(parsedHref.query.id, td3a.eq(n), tds, false)
         .release;
@@ -103,7 +103,7 @@ var parseTorrents = function(body, callback) {
 
       // torrent info
       tAnchor = tds.first().find('a').eq(2);
-      parsedHref = url.parse(ent.decode(tAnchor.attr('href')), true);
+      parsedHref = url.parse(decode(tAnchor.attr('href')), true);
       t.torrent = parseTorrentInfo(parsedHref.query.torrentid,
                                    tAnchor.text().trim(),
                                    tds, false);
@@ -122,7 +122,7 @@ var parseTorrents = function(body, callback) {
       t.artist = parseArtist(td3a.eq(2));
 
       n = t.artist === null ? 2 : 3;
-      parsedHref = url.parse(ent.decode(td3a.eq(n).attr('href')), true);
+      parsedHref = url.parse(decode(td3a.eq(n).attr('href')), true);
       r = parseRelease(parsedHref.query.id, td3a.eq(n), tds, true);
 
       // release info
@@ -155,12 +155,12 @@ var getOrigname = function(a, b) {
 // Parses an artist link
 //
 var parseArtist = function(a) {
-  var parsedHref = url.parse(ent.decode(a.attr('href')), true);
+  var parsedHref = url.parse(decode(a.attr('href')), true);
   if (parsedHref.pathname !== 'artist.php') return null;
 
   return {
       id      : parseInt(parsedHref.query.id, 10)
-    , name    : ent.decode(a.text().trim())
+    , name    : decode(a.text().trim())
     , orgname : getOrigname(a, 'View Artist')
   };
 };
@@ -171,7 +171,7 @@ var parseArtist = function(a) {
 //
 var parseRelease = function(id, a, tds, single) {
   // get release id and title
-  var title = ent.decode(a.text().trim())
+  var title = decode(a.text().trim())
     , td3split = tds.eq(3).text().trim().split('\t\t\t')
     , rs, regex, data, str, date, comments, tags
     ;
@@ -254,7 +254,7 @@ var parseTorrentInfo = function(id, str, tds, single) {
     , filetype  : filetype || null
     , quality   : quality || null
     , source    : source || null
-    , reissue   : reissue ? ent.decode(reissue) : null
+    , reissue   : reissue ? decode(reissue) : null
     , freeleech : freeleech || false
     , files     : parseInt(tds.eq(1 + n).text().trim(), 10)
     , added     : tds.eq(2 + n).text().trim()

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
     "test": "vows test/*-test.js --spec"
   },
   "dependencies": {
-    "request": "2.1.x",
+    "he": "~0.1.1",
     "jquery": "1.6.x",
-    "ent": "0.0.x"
+    "request": "2.1.x"
   },
   "devDependencies": {
+    "eyes": "0.1.x",
     "nock": "0.1.x",
-    "vows": "0.5.x",
-    "eyes": "0.1.x"
+    "vows": "0.5.x"
   },
   "licenses": [ {
     "type": "MIT",


### PR DESCRIPTION
ent is buggy for astral symbols. E.g. `ent.decode('&#x1d306;')` returns an incorrect result. [_he_](http://mths.be/he) handles these entities just fine.
